### PR TITLE
dynamic client factory now checks if a method was already collected

### DIFF
--- a/dotnet/src/UJMW.DynamicClient/DynamicClientFactory.cs
+++ b/dotnet/src/UJMW.DynamicClient/DynamicClientFactory.cs
@@ -508,6 +508,7 @@ namespace System.Web.UJMW {
 
     private static void CollectAllMethodsForType(Type t, List<MethodInfo> target) {
       foreach (MethodInfo mi in t.GetMethods()) {
+        if (target.Contains(mi)) continue;
         target.Add(mi);
       }
       if(t.BaseType != null) {

--- a/dotnet/test/UJMW.Tests/DynamicClientFactoryTests.cs
+++ b/dotnet/test/UJMW.Tests/DynamicClientFactoryTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Web.UJMW
+{
+  [TestClass]
+  public class DynamicClientFactoryTests
+  {
+    public interface IBaseInterface
+    {
+      void FirstMethod();
+    }
+
+    public interface IIntermediateInterface : IBaseInterface
+    {
+      new void FirstMethod();
+      void SecondMethod();
+    }
+
+    public interface IDerivedInterface : IIntermediateInterface
+    {
+      new void FirstMethod();
+      void ThirdMethod();
+    }
+
+    [TestMethod]
+    public void CreateInstance_InterfaceWithInheritanceChainAndShadowing_ShouldNotCauseException()
+    {
+      DynamicClientFactory.CreateInstance<IDerivedInterface>();
+    }
+  }
+
+}

--- a/dotnet/test/UJMW.Tests/UJMW.Tests.projitems
+++ b/dotnet/test/UJMW.Tests/UJMW.Tests.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Lib</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)DynamicClientFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DynamicClientTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
.net reflection returns methods multiple times if interface inheritance is used, which caused a System.TypeLoadException when trying to build a client.